### PR TITLE
feat: initial read-only fork (ro.buildwithoracle.com)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
-  "name": "maw-ui",
+  "name": "maw-ui-ro",
   "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "build:ro": "VITE_READONLY_BUILD=true vite build",
+    "preview": "vite preview",
+    "deploy": "bun run build:ro && wrangler deploy --config wrangler.ro.json"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,8 +43,19 @@ if (urlHost) {
 
 const hostParam = localStorage.getItem(STORAGE_KEY);
 
+/**
+ * Compile-time read-only build flag.
+ *
+ * When `VITE_READONLY_BUILD=true` is set at build time (see `build:ro` npm
+ * script + wrangler.ro.json), `isRemote` is forced true regardless of whether
+ * the viewer has a stored host. This is the only mechanism the fork uses to
+ * flip the UI into read-only mode — individual write paths are still guarded
+ * by the existing `isRemote` checks inherited from the upstream repo.
+ */
+export const isReadonlyBuild = import.meta.env.VITE_READONLY_BUILD === "true";
+
 /** Whether we're running in remote mode */
-export const isRemote = !!hostParam;
+export const isRemote = isReadonlyBuild || !!hostParam;
 
 /** Where the active host came from (always "config" or "local" after redirect) */
 export const hostSource: "config" | "local" =

--- a/wrangler.ro.json
+++ b/wrangler.ro.json
@@ -1,0 +1,7 @@
+{
+  "name": "maw-ui-ro",
+  "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
+  "compatibility_date": "2025-01-01",
+  "assets": { "directory": "./dist" },
+  "routes": [{ "pattern": "ro.buildwithoracle.com", "custom_domain": true }]
+}


### PR DESCRIPTION
## Summary

Fork bootstrap. Serves \`ro.buildwithoracle.com\` as a read-only viewer of the maw fleet, inheriting all existing \`isRemote\`-based gating from the upstream \`maw-ui\`.

## What changed

- \`package.json\` name → \`maw-ui-ro\`; added \`build:ro\` and \`deploy\` scripts
- \`wrangler.ro.json\` — CF Worker \`maw-ui-ro\` on \`ro.buildwithoracle.com\` (CF Workers per CLAUDE.md, not Pages)
- \`src/lib/api.ts\` — \`isReadonlyBuild\` export + \`isRemote = isReadonlyBuild || !!hostParam\`. \`VITE_READONLY_BUILD=true\` at build time flips the whole UI into remote/readonly mode regardless of localStorage

## Deploy flow

\`\`\`bash
bun run deploy   # build:ro + wrangler deploy --config wrangler.ro.json
\`\`\`

## Already live

\`https://ro.buildwithoracle.com/\` — HTTP 200, serves the same entry points as god.buildwithoracle.com but with \`isRemote=true\` baked in.

## Follow-up (non-blocking)

- [ ] Compile-time strip of write paths (Vite plugin + dead-code elim on \`POST\`/\`PUT\`/\`DELETE\` fetch sites)
- [ ] Replace \`ConnectPage\` with a host-pinned splash (no host input — viewers don't pick)
- [ ] Subscribe to MQTT bridge for live updates without needing \`?host=\` + tunnel (Spike C)
- [ ] Smoke-test all 17 entry routes on \`ro.\` with no crash / no write attempts