### PR TITLE
fix(ro): purge private-IP hosts + skip PinLock in RO build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
-  "name": "maw-ui",
+  "name": "maw-ui-ro",
   "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "build:ro": "VITE_READONLY_BUILD=true vite build",
+    "preview": "vite preview",
+    "deploy": "bun run build:ro && wrangler deploy --config wrangler.ro.json"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,8 +43,19 @@ if (urlHost) {
 
 const hostParam = localStorage.getItem(STORAGE_KEY);
 
+/**
+ * Compile-time read-only build flag.
+ *
+ * When `VITE_READONLY_BUILD=true` is set at build time (see `build:ro` npm
+ * script + wrangler.ro.json), `isRemote` is forced true regardless of whether
+ * the viewer has a stored host. This is the only mechanism the fork uses to
+ * flip the UI into read-only mode — individual write paths are still guarded
+ * by the existing `isRemote` checks inherited from the upstream repo.
+ */
+export const isReadonlyBuild = import.meta.env.VITE_READONLY_BUILD === "true";
+
 /** Whether we're running in remote mode */
-export const isRemote = !!hostParam;
+export const isRemote = isReadonlyBuild || !!hostParam;
 
 /** Where the active host came from (always "config" or "local" after redirect) */
 export const hostSource: "config" | "local" =

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,8 +41,6 @@ if (urlHost) {
   window.location.replace(url.toString());
 }
 
-const hostParam = localStorage.getItem(STORAGE_KEY);
-
 /**
  * Compile-time read-only build flag.
  *
@@ -53,6 +51,20 @@ const hostParam = localStorage.getItem(STORAGE_KEY);
  * by the existing `isRemote` checks inherited from the upstream repo.
  */
 export const isReadonlyBuild = import.meta.env.VITE_READONLY_BUILD === "true";
+
+// RO build: viewers often carry a `maw-host` localStorage entry from their own
+// local-dev session (e.g. `localhost:3457`). That leaks their machine's private
+// address into API URLs on ro.buildwithoracle.com and hits ERR_CONNECTION_REFUSED /
+// ERR_SSL_PROTOCOL_ERROR. Purge anything pointing at loopback or RFC1918 so the
+// RO site only ever talks to real public hosts.
+if (isReadonlyBuild) {
+  const stored = localStorage.getItem(STORAGE_KEY) || "";
+  if (/localhost|127\.|192\.168\.|10\.|::1/.test(stored)) {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+const hostParam = localStorage.getItem(STORAGE_KEY);
 
 /** Whether we're running in remote mode */
 export const isRemote = isReadonlyBuild || !!hostParam;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,15 @@ import "./index.css";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { PinLock } from "./components/PinLock";
+import { isReadonlyBuild } from "./lib/api";
+
+// RO build bypasses PinLock entirely — the pin protects mutating fleet
+// actions, and RO has no mutations to protect. Viewers should see the UI
+// immediately without the gate.
+const body = isReadonlyBuild ? <App /> : <PinLock><App /></PinLock>;
 
 createRoot(document.getElementById("root")!).render(
   <ErrorBoundary>
-    <PinLock>
-      <App />
-    </PinLock>
+    {body}
   </ErrorBoundary>
 );

--- a/wrangler.ro.json
+++ b/wrangler.ro.json
@@ -1,0 +1,7 @@
+{
+  "name": "maw-ui-ro",
+  "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
+  "compatibility_date": "2025-01-01",
+  "assets": { "directory": "./dist" },
+  "routes": [{ "pattern": "ro.buildwithoracle.com", "custom_domain": true }]
+}


### PR DESCRIPTION
## Symptom

Viewer opened \`ro.buildwithoracle.com\` and console spammed:
\`\`\`
GET https://localhost:3457/api/ui-state net::ERR_CONNECTION_REFUSED
GET https://localhost:3457/api/asks net::ERR_CONNECTION_REFUSED
...
WebSocket wss://localhost:3457/ws failed
\`\`\`

## Root cause

Viewer had previously pasted \`?host=localhost:3457\` on this origin (for testing their local maw-js). That persisted to localStorage. On every RO visit from then on, \`api.ts\` read it back, built \`https://localhost:3457/api/...\` URLs, and hit the viewer's machine — which has no service on that port.

## Fix

- **\`src/lib/api.ts\`**: in RO build, purge \`maw-host\` if it matches loopback (\`localhost\`, \`127.\`, \`::1\`) or RFC1918 (\`192.168.\`, \`10.\`) before reading it.
- **\`src/main.tsx\`**: RO build skips PinLock entirely. The pin protects fleet mutations; RO has none. Viewers see UI immediately.

## Still TODO

RO needs a real public upstream. Two paths:
1. Cloudflared tunnel: \`mba:3456\` → \`mba.buildwithoracle.com\`, users pass \`?host=https://mba.buildwithoracle.com\`.
2. MQTT-only mode (Spike C, issue #40 on upstream) — no tunnel needed, subscribe to \`maw-mqtt-bridge.laris.workers.dev\`.