### PR TITLE
fix(ro): allow localhost, default bare localhost to http://

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
-  "name": "maw-ui",
+  "name": "maw-ui-ro",
   "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "build:ro": "VITE_READONLY_BUILD=true vite build",
+    "preview": "vite preview",
+    "deploy": "bun run build:ro && wrangler deploy --config wrangler.ro.json"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,8 +43,19 @@ if (urlHost) {
 
 const hostParam = localStorage.getItem(STORAGE_KEY);
 
+/**
+ * Compile-time read-only build flag.
+ *
+ * When `VITE_READONLY_BUILD=true` is set at build time (see `build:ro` npm
+ * script + wrangler.ro.json), `isRemote` is forced true regardless of whether
+ * the viewer has a stored host. This is the only mechanism the fork uses to
+ * flip the UI into read-only mode — individual write paths are still guarded
+ * by the existing `isRemote` checks inherited from the upstream repo.
+ */
+export const isReadonlyBuild = import.meta.env.VITE_READONLY_BUILD === "true";
+
 /** Whether we're running in remote mode */
-export const isRemote = !!hostParam;
+export const isRemote = isReadonlyBuild || !!hostParam;
 
 /** Where the active host came from (always "config" or "local" after redirect) */
 export const hostSource: "config" | "local" =

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -52,18 +52,6 @@ if (urlHost) {
  */
 export const isReadonlyBuild = import.meta.env.VITE_READONLY_BUILD === "true";
 
-// RO build: viewers often carry a `maw-host` localStorage entry from their own
-// local-dev session (e.g. `localhost:3457`). That leaks their machine's private
-// address into API URLs on ro.buildwithoracle.com and hits ERR_CONNECTION_REFUSED /
-// ERR_SSL_PROTOCOL_ERROR. Purge anything pointing at loopback or RFC1918 so the
-// RO site only ever talks to real public hosts.
-if (isReadonlyBuild) {
-  const stored = localStorage.getItem(STORAGE_KEY) || "";
-  if (/localhost|127\.|192\.168\.|10\.|::1/.test(stored)) {
-    localStorage.removeItem(STORAGE_KEY);
-  }
-}
-
 const hostParam = localStorage.getItem(STORAGE_KEY);
 
 /** Whether we're running in remote mode */
@@ -118,8 +106,16 @@ function resolveHost(): { httpProto: string; wsProto: string; host: string } | n
   if (hostParam.startsWith("http://")) {
     return { httpProto: "http:", wsProto: "ws:", host: hostParam.slice("http://".length).replace(/\/+$/, "") };
   }
-  // Bare host:port — default to https for backwards compatibility.
-  return { httpProto: "https:", wsProto: "wss:", host: hostParam.replace(/\/+$/, "") };
+  // Bare host:port — default protocol depends on target:
+  //   localhost / 127.* / ::1 → http (mkcert not required, and browsers allow
+  //     http://localhost from https pages as a "secure context" exception)
+  //   anything else → https (production tunnels expected)
+  const stripped = hostParam.replace(/\/+$/, "");
+  const isLoopback = /^(localhost|127\.|\[?::1\]?)/.test(stripped);
+  if (isLoopback) {
+    return { httpProto: "http:", wsProto: "ws:", host: stripped };
+  }
+  return { httpProto: "https:", wsProto: "wss:", host: stripped };
 }
 
 /** Build full URL for fetch() calls */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,8 +41,6 @@ if (urlHost) {
   window.location.replace(url.toString());
 }
 
-const hostParam = localStorage.getItem(STORAGE_KEY);
-
 /**
  * Compile-time read-only build flag.
  *
@@ -53,6 +51,20 @@ const hostParam = localStorage.getItem(STORAGE_KEY);
  * by the existing `isRemote` checks inherited from the upstream repo.
  */
 export const isReadonlyBuild = import.meta.env.VITE_READONLY_BUILD === "true";
+
+// RO build: viewers often carry a `maw-host` localStorage entry from their own
+// local-dev session (e.g. `localhost:3457`). That leaks their machine's private
+// address into API URLs on ro.buildwithoracle.com and hits ERR_CONNECTION_REFUSED /
+// ERR_SSL_PROTOCOL_ERROR. Purge anything pointing at loopback or RFC1918 so the
+// RO site only ever talks to real public hosts.
+if (isReadonlyBuild) {
+  const stored = localStorage.getItem(STORAGE_KEY) || "";
+  if (/localhost|127\.|192\.168\.|10\.|::1/.test(stored)) {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+const hostParam = localStorage.getItem(STORAGE_KEY);
 
 /** Whether we're running in remote mode */
 export const isRemote = isReadonlyBuild || !!hostParam;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,15 @@ import "./index.css";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { PinLock } from "./components/PinLock";
+import { isReadonlyBuild } from "./lib/api";
+
+// RO build bypasses PinLock entirely — the pin protects mutating fleet
+// actions, and RO has no mutations to protect. Viewers should see the UI
+// immediately without the gate.
+const body = isReadonlyBuild ? <App /> : <PinLock><App /></PinLock>;
 
 createRoot(document.getElementById("root")!).render(
   <ErrorBoundary>
-    <PinLock>
-      <App />
-    </PinLock>
+    {body}
   </ErrorBoundary>
 );

--- a/wrangler.ro.json
+++ b/wrangler.ro.json
@@ -1,0 +1,7 @@
+{
+  "name": "maw-ui-ro",
+  "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
+  "compatibility_date": "2025-01-01",
+  "assets": { "directory": "./dist" },
+  "routes": [{ "pattern": "ro.buildwithoracle.com", "custom_domain": true }]
+}


### PR DESCRIPTION
Revert private-IP purge + bare-localhost defaults to http://.

Viewers can now do `?host=localhost:3456` and RO will call `http://localhost:3456` — which maw-js serves. Browsers permit http://localhost from https pages (secure-context exception).

Prefixed hosts (http:// or https://) unchanged.

Use case: point ro.buildwithoracle.com at your own local maw-js for read-only self-inspection — no tunnel needed.