### PR TITLE
feat(ro): hide all inputs via .ro-mode body class

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,19 @@ body {
   overflow-x: hidden;
 }
 
+/* Read-only build — nuke every input surface. Body gets the `.ro-mode` class
+ * in src/main.tsx when VITE_READONLY_BUILD=true. Each selector matches the
+ * write elements that live across the upstream UI. Using display:none (not
+ * visibility:hidden) so the layout collapses cleanly. !important because
+ * some components set inline styles. */
+.ro-mode input,
+.ro-mode textarea,
+.ro-mode select,
+.ro-mode form,
+.ro-mode [contenteditable="true"] {
+  display: none !important;
+}
+
 /* All clickable elements show hand cursor */
 button, [role="button"], a[href], summary { cursor: pointer; }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,14 @@ import { isReadonlyBuild } from "./lib/api";
 // RO build bypasses PinLock entirely — the pin protects mutating fleet
 // actions, and RO has no mutations to protect. Viewers should see the UI
 // immediately without the gate.
+// The `.ro-mode` class on <body> drives a global CSS rule in index.css that
+// nukes every input / textarea / select / form across the inherited upstream
+// UI in one pass. Simpler than per-component VITE_READONLY_BUILD guards on
+// 30+ components — turn RO on or off by flipping one class.
+if (isReadonlyBuild) {
+  document.body.classList.add("ro-mode");
+}
+
 const body = isReadonlyBuild ? <App /> : <PinLock><App /></PinLock>;
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
30+ `<input>` / `<textarea>` / `<form>` / `<select>` / `contenteditable` sites inherited from upstream. One global CSS rule keyed on a `.ro-mode` body class collapses them all — no per-component guard drift when upstream adds new inputs.

- `src/main.tsx`: on RO build, `document.body.classList.add('ro-mode')`
- `src/index.css`: `.ro-mode input/textarea/select/form/[contenteditable] { display: none !important }`

`display:none` (not `visibility:hidden`) so layout collapses cleanly. `!important` because some upstream components set inline styles.